### PR TITLE
Move serial log backlog to sram2 section

### DIFF
--- a/.github/ci.yml
+++ b/.github/ci.yml
@@ -1,0 +1,44 @@
+# This is a wrapper around ci/runtests.sh
+# ci/runtests.sh is intended to be usable locally without github.
+
+name: ci
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  ci:
+    strategy:
+      matrix:
+        # no_override will use the version from rust-toolchain.toml
+        rust_version: [no_override, nightly]
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache Rust files
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/
+            target/ci/
+          # Save a unique cache each time
+          # (https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache)
+          key: rust-${{ matrix.rust_version }}-${{ github.run_id }}
+          # Load from the most recent match
+          restore-keys: |
+            rust-${{ matrix.rust_version }}
+
+      - name: Rustup ${{ matrix.rust_version }}
+        if: ${{ matrix.rust_version}} != "no_override"
+        run: |
+          rustup override set ${{ matrix.rust_version }}
+
+      - name: Build and test ${{ matrix.rust_version }}
+        run: ./ci/runtests.sh

--- a/ci/runtests.sh
+++ b/ci/runtests.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -v
+set -e
+
+export CARGO_TARGET_DIR=target/ci
+
+rustup target add thumbv7em-none-eabihf
+rustup component add rustfmt clippy
+
+export RUSTDOCFLAGS='-D warnings'
+export RUSTFLAGS="-D warnings"
+
+cargo fmt -- --check
+
+# Check everything first
+cargo check --locked
+cargo clippy
+
+# various features
+cargo build
+cargo build --all-features
+cargo build --no-default-features
+cargo build --features mctp-bench
+
+# release builds
+cargo build --release --all-features
+
+# Check syntax
+cargo doc
+
+# Record sizes
+cargo size --release
+readelf -S target/thumbv7em-none-eabihf/release/usbnvme
+
+echo success

--- a/link-ram.x
+++ b/link-ram.x
@@ -221,6 +221,15 @@ SECTIONS
     *(.sram3 .sram3.*);
     . = ALIGN(4); /* 4-byte align the end (VMA) of this section */
   } > SRAM3
+
+  /* ## SRAM uninit data. Doesn't have ECC. */
+  .sram2_uninit (NOLOAD) : ALIGN(4)
+  {
+    . = ALIGN(4);
+
+    *(.sram2_uninit .sram2_uninit.*);
+    . = ALIGN(4); /* 4-byte align the end (VMA) of this section */
+  } > SRAM2
 }
 
 /* Do not exceed this mark in the error messages below                                    | */

--- a/memory.x
+++ b/memory.x
@@ -15,7 +15,7 @@ MEMORY
     /* SRAM3 can be used for DMA */
     SRAM3 : ORIGIN = 0x24040000, LENGTH =  64K
 
-    /* non-ECC. Used by bootloader. */
+    /* non-ECC. Used by bootloader, and sram2_unit usbnvme data */
     SRAM2 : ORIGIN = 0x24020000, LENGTH =  128K
 }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 components = [ "llvm-tools" ]
-channel = "1.88"
+channel = "1.89"
 targets = [ "thumbv7em-none-eabihf" ]

--- a/src/main.rs
+++ b/src/main.rs
@@ -431,7 +431,7 @@ async fn nvme_mi_task(router: &'static Router<'static>) -> ! {
 /// A mctp-bench sender.
 ///
 /// Use with `mctp-bench` test tool from
-/// https://github.com/CodeConstruct/mctp. Asssumes receiver EID 90.
+/// <https://github.com/CodeConstruct/mctp>
 #[allow(unused)]
 #[embassy_executor::task]
 async fn bench_task(

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,8 @@
  */
 #![no_std]
 #![no_main]
+// avoid mysterious missing awaits
+#![deny(unused_must_use)]
 
 use embassy_sync::signal::Signal;
 #[allow(unused)]

--- a/src/pldm.rs
+++ b/src/pldm.rs
@@ -189,7 +189,8 @@ async fn pldm_run_file(
             PLDM_TYPE_CONTROL,
             PLDM_BASE_VERSION,
             &required,
-        );
+        )
+        .await;
 
         // Get Commands type 7
         let required = [
@@ -202,7 +203,8 @@ async fn pldm_run_file(
             PLDM_TYPE_FILE_TRANSFER,
             PLDM_FILE_VERSION,
             &required,
-        );
+        )
+        .await;
 
         // PDR Repository Info
         let pdr_info = platrq::get_pdr_repository_info(comm)


### PR DESCRIPTION
`mctp-bench` feature was failing to build due to lack of ram. The serial log can be moved to free up space. This adds CI to test various feature configurations.