### PR TITLE
Update nvme-mi-dev, xspiloader fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -739,8 +739,7 @@ checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 [[package]]
 name = "neotron-loader"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9b8634a088b9d5b338a96b3f6ef45a3bc0b9c0f0d562c7d00e498265fd96e8f"
+source = "git+https://github.com/Neotron-Compute/neotron-loader?rev=ab92cecd8a458044aef30b39c87112244deb69c6#ab92cecd8a458044aef30b39c87112244deb69c6"
 
 [[package]]
 name = "no_std_io2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,7 +773,7 @@ dependencies = [
 [[package]]
 name = "nvme-mi-dev"
 version = "0.1.0"
-source = "git+https://github.com/CodeConstruct/nvme-mi-dev#6dc246aae5fdc46d655b6e0b8126ec34546152d9"
+source = "git+https://github.com/CodeConstruct/nvme-mi-dev#b6614f2651dc46df5e7798c133a43669cebfee70"
 dependencies = [
  "crc",
  "deku 0.19.1 (git+https://github.com/sharksforarms/deku.git?rev=e5363bc11e123bfcfd3467a2a90aeef8b588f432)",

--- a/xspiloader/Cargo.toml
+++ b/xspiloader/Cargo.toml
@@ -17,4 +17,6 @@ cortex-m = { workspace = true }
 cortex-m-rt = { workspace = true }
 panic-probe = { workspace = true }
 
-neotron-loader = "0.1.0"
+# Required for ELF payloads build with Rust 1.89
+# https://github.com/Neotron-Compute/neotron-loader/pull/2
+neotron-loader = { git = "https://github.com/Neotron-Compute/neotron-loader", rev = "ab92cecd8a458044aef30b39c87112244deb69c6" }


### PR DESCRIPTION
This updates nvme-mi-dev with namespace management commands and sanitize/format.

A couple of xspiloader fixes are added - Rust 1.89 compatibility and support for using sram2 region (added in https://github.com/CodeConstruct/usbnvme/pull/1 )